### PR TITLE
Fix wrong case name in VtxData.cpp

### DIFF
--- a/shared/Scene/VtxData.cpp
+++ b/shared/Scene/VtxData.cpp
@@ -1,4 +1,4 @@
-#include "shared/scene/VtxData.h"
+#include "shared/Scene/VtxData.h"
 
 #include <algorithm>
 #include <assert.h>


### PR DESCRIPTION
works on Windows, but wrong case fails on Unix